### PR TITLE
Remove space from CONNECTION_ARGS variable assignment

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ rm -f /workdir/data/backup.date
 rm -rf $TARGET_DIR
 mkdir -p $TARGET_DIR
 
-CONNECTION_ARGS= "-h ${MONGO_HOST}"
+CONNECTION_ARGS="-h ${MONGO_HOST}"
 if [[ -n "$MONGO_URI" ]]; then 
     CONNECTION_ARGS="--uri ${MONGO_URI}"
 else 


### PR DESCRIPTION
The space means the variable assignment doesn't work..

```
$ cat /tmp/foo.sh
#!/bin/bash

FOO= "foo"
BAR="bar"
echo "FOO=${FOO}"
echo "BAR=${BAR}"
$ /tmp/foo.sh         
/tmp/foo.sh: line 3: foo: command not found
FOO=
BAR=bar
```

Backups are failing in staging as a result